### PR TITLE
fix: xticklabelpad applied in wrong direction

### DIFF
--- a/src/geoaxis.jl
+++ b/src/geoaxis.jl
@@ -225,7 +225,7 @@ function draw_geoticks!(ax::Axis, hijacked_observables, line_density, remove_ove
         else
             xtickpoints.val = xtickpoints.val .+ directional_pad.(
                 Ref(scene), Ref(limits), _xtickpos_in_inputspace,
-                _xticklabels, Ref(Point2f(ax.xticklabelpad[], 0)), ax.xticklabelsize[], ax.xticklabelfont[],
+                _xticklabels, Ref(Point2f(0, ax.xticklabelpad[])), ax.xticklabelsize[], ax.xticklabelfont[],
                 ax.xticklabelrotation[]
             )
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -254,7 +254,8 @@ function directional_pad(scene, limits, tickcoord_in_inputspace, ticklabel::Abst
     # determine direction to go in order to stay inbounds.
     xdir = tickcoord_in_inputspace[1] < 0 ? +1 : -1
     ydir = tickcoord_in_inputspace[2] < 0 ? +1 : -1
-    Δs = Vec2f(xdir, ydir) .* tickpad ./ sum(tickpad) * ds
+    Δs = iszero(sum(tickpad)) ? Vec2f(0) : Vec2f(xdir, ydir) .* tickpad ./ (sum(tickpad)) * ds
+    
     # find the x and y directions
     # multiply by the sign in order to have them going outwards at any point
     Σp = sign(sum(Δs)) * inv_tfunc(tickcoord_in_dataspace + Δs)


### PR DESCRIPTION
fix xticklabelpad being applied in x-direction, not y-direction. 

With the code provided in #137, I now get the output:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/45243236/203637453-18c7ec82-4d73-41e9-8ae3-8d07435ff3ce.png">
In bottom-left figure, xlabels are no longer overlapping with bottom spine.
In bottom-right figure, xlabels are shifted down, as expected, but there seem to be some leftward shift resulting in slightly overlapping x-ticks.
Unfortunately, this does not fix the top-right figure, where xlabel ticks are still missing.

-------
This PR also fixes an issue where, if `xticklabelpad=0`, 
```julia
julia> fig = Figure()

julia> ga = GeoAxis(fig[1,1]; coastlines = true, dest = "+proj=longlat", xticklabelpad=0);
```
I would get this output:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/45243236/203638186-4f6cc7f2-46a6-4fb9-8bfe-736cdd217200.png">
but, with this PR, I get:
<img width="397" alt="image" src="https://user-images.githubusercontent.com/45243236/203638378-74cb11b1-9e92-49d7-a9a6-91baac407d59.png">
This is because we would divide by zero in `directional_pad`, resulting in `NaN` positioning of ticks.

------
I wouldn't claim this closes #137, since I'd still like for lonticks to appear in the top-right plot, but it's a step in the right direction.