### PR TITLE
WIP: support for a few `naturalearthdata` datasets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Proj = "c94c279d-25a6-4763-9509-64d165bea63e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+Shapefile = "8e980c4a-a4fe-5da2-b3a7-4b4b0353a2f4"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -21,3 +21,60 @@ function land()
         return geo2basic(geometry)
     end
 end
+
+function coastlines_10m()
+    # https://www.naturalearthdata.com/downloads/10m-physical-vectors/10m-coastline/
+    temppath = abspath(joinpath(homedir(), "Downloads/ne_10m_coastline/ne_10m_coastline.shp"))
+    geoms = Shapefile.shapes(Shapefile.Table(temppath))
+    return map(geo2basic, geoms)
+end
+
+function land_50m()
+    # https://www.naturalearthdata.com/downloads/50m-physical-vectors/50m-land/
+    temppath = abspath(joinpath(homedir(), "Downloads/ne_50m_land/ne_50m_land.shp"))
+    geoms = Shapefile.shapes(Shapefile.Table(temppath))
+    return map(geo2basic, geoms)
+end
+
+"""
+Adds support for ocean bathymetry datasets.
+Currently tested on: https://www.naturalearthdata.com/downloads/10m-physical-vectors/10m-bathymetry/
+(download all data)
+
+The function returns a MultiPolygon describing the bathymetry at a given depth contour.
+
+The following depths should be available: [10000, 9000, 8000, 7000, 6000, 5000, 4000, 3000, 2000, 1000, 200, 0]
+"""
+function bathymetry(contour::Int=2000)
+    path = abspath(joinpath(homedir(), "Downloads/ne_10m_bathymetry_all/"))
+    bathyfiles = filter(x-> endswith(x, ".shp"), readdir(path; join=true))
+    # Extract depth signifier from filename
+    depths = parse.(Int, getfield.(match.(r"\d+(?=.shp)", bathyfiles), :match))
+    # Extract the file corresponding to the contour
+    fileind = findfirst(==(contour), depths)
+    isnothing(fileind) && error("Contour $contour not found. Available contours: $depths")
+    
+    # Open bathymetry file
+    bathyfile = bathyfiles[fileind]
+    geoms = Shapefile.shapes(Shapefile.Table(bathyfile))
+    poly_multipoly = map(geo2basic, geoms)
+    many_poly = reduce(vcat, poly_multipoly)  # flatten multiple Polygons and MultiPolygons to many Polygons
+    return GeometryBasics.MultiPolygon(many_poly)  # turn all single Polygons into a single MultiPolygon
+end
+
+"""
+Ocean bottom, similar to `earth()`, but higher resolution, at 50m.
+
+Download here: https://www.naturalearthdata.com/downloads/50m-ocean-bottom/50m-ocean-bottom/
+
+Plot by:
+```julia
+julia> bathy = oceanbottom_50m()
+
+julia> img = image!(-180..180, -90..90, rotr90(bathy); interpolate = false)
+```
+"""
+function oceanbottom_50m()
+    path = abspath(joinpath(homedir(), "Downloads/OB_50M/OB_50M.tif"))
+    return FileIO.load(path)
+end


### PR DESCRIPTION
WIP on support for plotting various datasetes from [naturalearthdata.com](http://www.naturalearthdata.com/downloads/).

The website provides a plethora of datasets that are very nice to use as background images / overlays on Earth-themed plots.

Some comments:
* Technically, this PR primarily adds support for reading certain shapefiles using the `Shapefile` package.
* Some files in the illustrative examples, below, are quite large and you'd likely not want to include them in this package. Some options are:
  * Add the data URLs as [Artifacts](https://pkgdocs.julialang.org/v1/artifacts/). I don't know much about this option, but it seems like all data is downloaded when the package is installed. This could be nice for small datafiles, but may be inconvenient for files larger than e.g. 100MB.
  * Use `Downloads` (or a similar package) to download these files upon request. This is already done for certain examples in this repo.
  * Let the user provide a path to the functions, leaving it in the user's hands to obtain any relevant data.
  * This is the wrong repo -- there should be another repo that provides this type of support, and adds relevant methods that `GeoMakie`/`Makie` can interface with.

Personally, I'm most interested in plotting more accurate coastlines and ocean bottom, so will probably not work on too much support beyond this.

**Note:**
Just before posting I saw that they may actually have `.geojson`-type data available for download via github [[link](https://github.com/nvkelso/natural-earth-vector/tree/master/geojson)], so the `Shapefile` support may not be needed (at least for these datasets). If the maintainers prefer people to individually download any datasets they may need, I may be happy with adding some info about this to the docs, for others to enjoy.

-------------
## 1. Higher-resolution `coastlines()`
For this example, I assume the relevant data exists in `~/Downloads/ne_10m_coastline/ne_10m_coastline.shp` ([download here](https://www.naturalearthdata.com/downloads/10m-physical-vectors/10m-coastline/))
```julia
julia> using GeoMakie, GLMakie

julia> fig = Figure(; resolution=(1800,1000))

julia> ga11 = GeoAxis(fig[1,1]; coastlines = false, dest = "+proj=longlat", title="World");

julia> ga12 = GeoAxis(fig[1,2]; coastlines = true, dest = "+proj=longlat", title="Norway", lonlims=(2.5, 20), latlims=(57, 65));

julia> ga21 = GeoAxis(fig[2,1]; coastlines = true, dest = "+proj=longlat", title="Greece", lonlims=(19, 32), latlims=(35, 42));

julia> ga22 = GeoAxis(fig[2,2]; coastlines = true, dest = "+proj=longlat", title="Hawaii", lonlims=(-161, -154), latlims=(20, 23));

julia> lines!.([ga11, ga12, ga21, ga22], Ref(GeoMakie.coastlines_10m()); color=:red);
```
<img width="897" alt="image" src="https://user-images.githubusercontent.com/45243236/203690223-45326987-d292-4ad1-b244-d639b8f1b9a1.png">

## 2. Bathymetry contours
Assumes you have the folder `~/Downloads/ne_10m_bathymetry_all/` (_download all_ [here](https://www.naturalearthdata.com/downloads/10m-physical-vectors/10m-bathymetry/))
```julia
julia> fig = Figure(; resolution=(1800,1000))

julia> ga = GeoAxis(fig[1,1]; coastlines = true, dest = "+proj=longlat");

julia> bathyplot = lines!(GeoMakie.bathymetry(2000); color=(:red, 0.8));

julia> bathyplot = lines!(GeoMakie.bathymetry(3000); color=(:darkred, 0.8));
```
<img width="895" alt="image" src="https://user-images.githubusercontent.com/45243236/203693571-be59ee11-9825-46f2-afdf-8873005837da.png">
(Note: I'm not sure if the long straight-ish lines are due to one-off indexing errors on my part in how I read the raw data or if they're actually a part of the dataset).

## 3. Detailed ocean bottom
Assumes you have the file `~/Downloads/OB_50M/OB_50M.tif` ([download here](https://www.naturalearthdata.com/downloads/50m-ocean-bottom/50m-ocean-bottom/))
```julia
julia> fig = Figure(; resolution=(1800,1800))

julia> ga = GeoAxis(fig[1,1]; coastlines = true, dest = "+proj=longlat", lonlims = (-180, -125), latlims=(-40,-15));

julia> ga2 = GeoAxis(fig[2,1]; coastlines = true, dest = "+proj=longlat", lonlims = (-180, -125), latlims=(-40,-15));

julia> img = image!(ga, -180..180, -90..90, rotr90(GeoMakie.earth()); interpolate = false);  # regular earth

julia> img = image!(ga2, -180..180, -90..90, rotr90(GeoMakie.oceanbottom_50m()); interpolate = false);

# Optionally, also add the high-res coastplot

julia> coastplot = lines!(ga2, GeoMakie.coastlines_10m(); color=:black);

julia> coastplot = lines!(ga, GeoMakie.coastlines_10m(); color=:black);
```

<img width="893" alt="image" src="https://user-images.githubusercontent.com/45243236/203694630-868f449b-4894-4b48-84af-49dc25304f2d.png">
Here the combination of detailed bathymetry and detailed coastplot really shines, and it becomes apparent the regions where the bathymetry permeates the ocean surface as islands.
