### PR TITLE
transformation typo

### DIFF
--- a/src/geoaxis.jl
+++ b/src/geoaxis.jl
@@ -78,7 +78,7 @@ function GeoAxis(args...;
 
     _transformation = Observable{Proj.Transformation}(Makie.to_value(transformation))
      Makie.Observables.onany(source, dest) do src, dst
-        _transformation[] = Proj.Transformation(Makie.to_value(src), Makie.to_value(dest); always_xy = true)
+        _transformation[] = Proj.Transformation(Makie.to_value(src), Makie.to_value(dst); always_xy = true)
     end
     Makie.Observables.onany(transformation) do trans
         _transformation[] = trans


### PR DESCRIPTION
seems to just be a small typo. it doesn't seem to affect anything really, but probably better to have the do-block be proper.