### PR TITLE
Multi-level choropleths

### DIFF
--- a/src/multilevelchoropleth.jl
+++ b/src/multilevelchoropleth.jl
@@ -1,0 +1,9 @@
+struct RelatedLayers
+  layers::Vector{DataFrame}
+end
+
+@recipe(MultiLevelChoropleth) do scene
+  Attributes(
+    
+  )
+end


### PR DESCRIPTION
It is often the case that you might want to color the provinces of a country by some variable, but also display higher-level administrative divisions like states.  We introduce a recipe `multilevelchoropleth` which allows this to be done quickly and easily.

The basic concept is that countries have divisions of various admin levels.  Admin 1 (state) is composed of multiple admin 2 (province) which is composed of multiple admin 3 (district).  We need a wrapper type, which is capable of automatically determining the linkages between these admin level geometries, and we need a recipe which can plot at any admin level yet still show all outlines.

The final product might look something like this:

![try1](https://user-images.githubusercontent.com/32143268/226839054-da50d240-de07-4113-a1c9-06c897dcdd7f.png)
