### PR TITLE
don't omit all digits when printing ticks

### DIFF
--- a/src/geoaxis.jl
+++ b/src/geoaxis.jl
@@ -507,7 +507,8 @@ function vis_spine!(points, text, points_px, d, mindist, labeloffset)
         # TODO use xticklabelpad
         p_offset = p_px .+ (p.dir .* (3 * labeloffset))
         push!(points_px, p_offset)
-        push!(text, string(round(Int, p.input[d]), "°"))
+		x = round(p.input[d]; sigdigits = 3)
+        push!(text, string(isinteger(x) ? round(Int, x) : x, "°"))
     end
 end
 


### PR DESCRIPTION
Encountered this when setting `xticks` to `0:2.5:20` and getting the following tick labels:

![image](https://github.com/user-attachments/assets/fddf5201-3f4b-4593-9d0c-70425794f71c)

3 significant digits is still a rather arbitrary choice but seems better than the current behavior.